### PR TITLE
Added new endpoints

### DIFF
--- a/backend/src/controllers/matches.js
+++ b/backend/src/controllers/matches.js
@@ -10,10 +10,72 @@ const ALLOWED_STAT_FIELDS = [
   "minutes_played",
 ];
 
+const MATCH_REQUIRED_FIELDS = [
+  "opponent",
+  "match_date",
+  "location",
+  "score_home",
+  "score_away",
+];
+
 const extractStatFields = (body) => {
   return Object.fromEntries(
     Object.entries(body).filter(([key]) => ALLOWED_STAT_FIELDS.includes(key)),
   );
+};
+
+export const getMatches = async (req, res) => {
+  try {
+    const matches = await matchService.getMatchesByTeam(
+      req.params.teamId,
+      req.coach.id,
+    );
+    res.json(matches);
+  } catch (err) {
+    res.status(err.status ?? 500).json({ error: err.message });
+  }
+};
+
+export const createMatch = async (req, res) => {
+  const { opponent, match_date, location, score_home, score_away } = req.body;
+
+  const missing = MATCH_REQUIRED_FIELDS.filter(
+    (field) => req.body[field] === undefined,
+  );
+  if (missing.length > 0) {
+    return res
+      .status(400)
+      .json({ error: `Følgende felter mangler: ${missing.join(", ")}` });
+  }
+
+  try {
+    const match = await matchService.createMatch(
+      req.params.teamId,
+      req.coach.id,
+      {
+        opponent,
+        match_date: new Date(match_date),
+        location,
+        score_home: parseInt(score_home),
+        score_away: parseInt(score_away),
+      },
+    );
+    res.status(201).json(match);
+  } catch (err) {
+    res.status(err.status ?? 500).json({ error: err.message });
+  }
+};
+
+export const getMatch = async (req, res) => {
+  try {
+    const match = await matchService.getMatchById(
+      req.params.matchId,
+      req.coach.id,
+    );
+    res.json(match);
+  } catch (err) {
+    res.status(err.status ?? 500).json({ error: err.message });
+  }
 };
 
 export const getMatchStats = async (req, res) => {

--- a/backend/src/routes/matches.js
+++ b/backend/src/routes/matches.js
@@ -1,9 +1,10 @@
 import { Router } from "express";
-import * as matchStatsController from "../controllers/matches.js";
+import * as matchController from "../controllers/matches.js";
 
-const router = Router();
+const router = Router({ mergeParams: true });
 
-router.get("/:matchId/stats", matchStatsController.getMatchStats);
-router.post("/:matchId/stats", matchStatsController.upsertStats);
+router.get("/:matchId/stats", matchController.getMatchStats);
+router.post("/:matchId/stats", matchController.upsertStats);
+router.get("/:matchId", matchController.getMatch);
 
 export default router;

--- a/backend/src/routes/teams.js
+++ b/backend/src/routes/teams.js
@@ -1,9 +1,13 @@
 import { Router } from "express";
 import * as teamsController from "../controllers/teams.js";
+import * as matchController from "../controllers/matches.js";
 
-const router = Router();
+const router = Router({ mergeParams: true });
 
 router.post("/", teamsController.createTeam);
 router.get("/:id", teamsController.getTeam);
+
+router.get("/:teamId/matches", matchController.getMatches);
+router.post("/:teamId/matches", matchController.createMatch);
 
 export default router;

--- a/backend/src/services/matches.js
+++ b/backend/src/services/matches.js
@@ -2,6 +2,94 @@ import pkg from "@prisma/client";
 const { PrismaClient } = pkg;
 import { prisma } from "../lib/prisma.js";
 
+export const getMatchesByTeam = async (teamId, coachId) => {
+  const team = await prisma.team.findUnique({
+    where: { id: teamId },
+  });
+
+  if (!team) {
+    const error = new Error("Hold ikke fundet");
+    error.status = 404;
+    throw error;
+  }
+
+  if (team.coach_id !== coachId) {
+    const error = new Error("Du har ikke adgang til dette hold");
+    error.status = 403;
+    throw error;
+  }
+
+  const matches = await prisma.match.findMany({
+    where: { team_id: teamId },
+    orderBy: { match_date: "desc" },
+  });
+
+  return matches;
+};
+
+export const createMatch = async (teamId, coachId, data) => {
+  const team = await prisma.team.findUnique({
+    where: { id: teamId },
+  });
+
+  if (!team) {
+    const error = new Error("Hold ikke fundet");
+    error.status = 404;
+    throw error;
+  }
+
+  if (team.coach_id !== coachId) {
+    const error = new Error("Du har ikke adgang til dette hold");
+    error.status = 403;
+    throw error;
+  }
+
+  const match = await prisma.match.create({
+    data: {
+      team_id: teamId,
+      ...data,
+    },
+  });
+
+  return match;
+};
+
+export const getMatchById = async (matchId, coachId) => {
+  const match = await prisma.match.findUnique({
+    where: { id: matchId },
+    include: {
+      team: true,
+      matchStats: {
+        include: {
+          player: {
+            select: {
+              id: true,
+              first_name: true,
+              last_name: true,
+              jersey_number: true,
+            },
+          },
+        },
+        orderBy: { player: { jersey_number: "asc" } },
+      },
+    },
+  });
+
+  if (!match) {
+    const error = new Error("Kamp ikke fundet");
+    error.status = 404;
+    throw error;
+  }
+
+  if (match.team.coach_id !== coachId) {
+    const error = new Error("Du har ikke adgang til denne kamp");
+    error.status = 403;
+    throw error;
+  }
+
+  return match;
+};
+
 export const getStatsByMatch = async (matchId, coachId) => {
   const match = await prisma.match.findUnique({
     where: { id: matchId },


### PR DESCRIPTION
## Description
<!-- Briefly describe what this PR does and why -->
Tilføjet følgende endpoints:
GET /teams/:teamId/matches - liste af alle kampe (sorter efter dato)
Eksempel:
```
curl http://localhost:3001/teams/3bd8868b-8b13-405b-8eb1-dec0819c014d/matches -H "Authorization: Bearer eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJpZCI6IjVkZjk2NzBjLTAwN2EtNDgzNy1iYTg2LTk4MGMzYmVkN2MwNiIsImVtYWlsIjoiY29hY2htYWlsQG1haWwuY29tIiwiaWF0IjoxNzc3MTQ5ODQ0LCJleHAiOjE3Nzc3NTQ2NDR9.guYqeU1mCMoKEirD3MXn_FdHBWctYy_UWwNGwX1HUjY" | jq
  % Total    % Received % Xferd  Average Speed   Time    Time     Time  Current
                                 Dload  Upload   Total   Spent    Left  Speed
100   213  100   213    0     0   1701      0 --:--:-- --:--:-- --:--:--  1704
[
  {
    "id": "6553ed48-491d-4075-b4dc-e90370e25145",
    "team_id": "3bd8868b-8b13-405b-8eb1-dec0819c014d",
    "opponent": "De seje rejer",
    "match_date": "2026-04-25T20:42:49.491Z",
    "location": "AWAY",
    "score_home": 67,
    "score_away": 69
  }
]
```

POST /teams/:teamId/matches - opret en kamp
Eksempel:
```
curl http://localhost:3001/teams/3bd8868b-8b13-405b-8eb1-dec0819c014d/matches -X POST -H "Content-Type
: application/json" -H "Authorization: Bearer eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJpZCI6IjVkZjk2NzBjLTAwN2EtNDgzNy1iYTg2LTk4MGMzYmVkN2MwNiIsImVtYWlsIjoiY29hY2htYWlsQG1haWwuY29tIiwiaWF0IjoxNzc3MTQ5ODQ0LCJleHAiOjE3Nzc3NTQ2NDR9.guYqeU1mCMoKEirD3MXn_FdHBWctYy_UWwNGwX1HUjY" -d '{
  "opponent": "Randers HK",
  "match_date": "2026-05-01T18:00:00.000Z",
  "location": "HOME",
  "score_home": 28,
  "score_away": 24
}'
{"id":"57f23376-6800-4ec5-bf14-a681a36583d9","team_id":"3bd8868b-8b13-405b-8eb1-dec0819c014d","opponent":"Randers HK","match_date":"2026-05-01T18:00:00.000Z","location":"HOME","score_home":28,"score_away":24}
```

GET /matches/:id - hent en enkelt kamp med alle spiller stats
Eksempel:
```
curl http://localhost:3001/matches/6553ed48-491d-4075-b4dc-e90370e25145 -H "Authorization: Bearer eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJpZCI6IjVkZjk2NzBjLTAwN2EtNDgzNy1iYTg2LTk4MGMzYmVkN2MwNiIsImVtYWlsIjoiY29hY2htYWlsQG1haWwuY29tIiwiaWF0IjoxNzc3MTQ5ODQ0LCJleHAiOjE3Nzc3NTQ2NDR9.guYqeU1mCMoKEirD3MXn_FdHBWctYy_UWwNGwX1HUjY" | jq
  % Total    % Received % Xferd  Average Speed   Time    Time     Time  Current
                                 Dload  Upload   Total   Spent    Left  Speed
100   704  100   704    0     0  55004      0 --:--:-- --:--:-- --:--:-- 58666
{
  "id": "6553ed48-491d-4075-b4dc-e90370e25145",
  "team_id": "3bd8868b-8b13-405b-8eb1-dec0819c014d",
  "opponent": "De seje rejer",
  "match_date": "2026-04-25T20:42:49.491Z",
  "location": "AWAY",
  "score_home": 67,
  "score_away": 69,
  "team": {
    "id": "3bd8868b-8b13-405b-8eb1-dec0819c014d",
    "coach_id": "5df9670c-007a-4837-ba86-980c3bed7c06",
    "name": "cool team"
  },
  "matchStats": [
    {
      "id": "137f6e08-0233-478e-be49-abd904c4a196",
      "match_id": "6553ed48-491d-4075-b4dc-e90370e25145",
      "player_id": "01f9d29e-dc49-435b-8cc1-f5ef7c23a161",
      "goals": 100,
      "assists": 0,
      "shots": 0,
      "saves": 0,
      "yellow_cards": 0,
      "red_cards": 0,
      "minutes_played": 0,
      "player": {
        "id": "01f9d29e-dc49-435b-8cc1-f5ef7c23a161",
        "first_name": "pelle",
        "last_name": "pedel",
        "jersey_number": 69
      }
    }
  ]
}
```


## Related Issue
Closes #24 

## Type of Change
<!-- Check all that apply -->
- [ ] 🐛 Bug fix
- [ ] ✨ New feature
- [ ] 🔨 Refactor
- [ ] 📝 Documentation
- [ ] 🎨 Styling / UI
- [ ] ⚙️ Configuration / setup

## What Was Done
<!-- Bullet points summarizing your changes -->
- 
- 

## How to Test
<!-- Steps for the reviewer to verify your changes work -->
1. 
2. 

## Screenshots (if applicable)
<!-- Add screenshots for UI changes -->

## Checklist
- [ ] My code follows the project's coding style
- [ ] I have tested my changes locally
- [ ] I have not introduced any new warnings or errors
- [ ] I have updated documentation if needed
- [ ] This PR is ready for review (not a draft)
