### PR TITLE
Fix #83: translate win/loss/draw and home/away to Danish

### DIFF
--- a/frontend/src/components/Rows/MatchRow.jsx
+++ b/frontend/src/components/Rows/MatchRow.jsx
@@ -31,12 +31,12 @@ export default function MatchRow({ data }) {
                           : "var(--navy)",
                   }}
                 >
-                  <>{info.result}</>
+                  <>{info.result === "win" ? "Sejr" : info.result === "loss" ? "Nederlag" : "Uafgjort"}</>
                 </div>
               )}
             </div>
             <div className={rowStyles.textdiv}>
-              <p className={rowStyles.locText}>{info.location}</p>
+              <p className={rowStyles.locText}>{info.location === "home" ? "Hjemme" : "Ude"}</p>
             </div>
           </div>
           <div className={styles.container}>


### PR DESCRIPTION
## Description
Ændret win/loss/draw til sejr/nederlag/uafgjort og har ændret home/away til Hjemme/Ude


## Related Issue
Closes #83

## Type of Change
<!-- Check all that apply -->
- [ ] 🐛 Bug fix
- [ ] ✨ New feature
- [ ] 🔨 Refactor
- [ ] 📝 Documentation
- [ ] 🎨 Styling / UI
- [ ] ⚙️ Configuration / setup

## What Was Done
<!-- Bullet points summarizing your changes -->
- 
- 

## How to Test
<!-- Steps for the reviewer to verify your changes work -->
1. 
2. 

## Screenshots (if applicable)
<!-- Add screenshots for UI changes -->

## Checklist
- [ ] My code follows the project's coding style
- [ ] I have tested my changes locally
- [ ] I have not introduced any new warnings or errors
- [ ] I have updated documentation if needed
- [ ] This PR is ready for review (not a draft)
